### PR TITLE
Add chat room discovery and private server options

### DIFF
--- a/private_chat_handler.sh
+++ b/private_chat_handler.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Handler script for private chat connections
+# Sends password prompt and validates before opening chat
+
+# Notify client password is required
+echo "PASSWORD_REQUIRED"
+read -r client_pass || exit 1
+if [ "$client_pass" = "$CHAT_PASSWORD" ]; then
+    echo "Access granted. Start chatting."
+    exec cat
+else
+    echo "Wrong password"
+fi


### PR DESCRIPTION
## Summary
- support public/private chat servers
- add handler script for password-protected chat
- detect password requirement when joining
- implement network discovery of available chat rooms
- expand main menu with discovery and server options

## Testing
- `bash -n ews.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fd9149494832f99404dba4e08a718